### PR TITLE
Config/lgs setup arbitrum networks

### DIFF
--- a/hardhat/erc20-token/hardhat.config.ts
+++ b/hardhat/erc20-token/hardhat.config.ts
@@ -19,5 +19,15 @@ module.exports = {
       url: "https://rpc.sepolia.org",
       chainId: 11155111,
     },
+    arbitrumOne: {
+      accounts: [process.env.PK],
+      url: 'https://arb1.arbitrum.io/rpc',
+      chainId: 42161
+    },
+    arbitrumSepolia: {
+      accounts: [process.env.PK],
+      url: 'https://sepolia-rollup.arbitrum.io/rpc',
+      chainId: 421614
+    },
   },
 };

--- a/hardhat/erc20-token/hardhat.config.ts
+++ b/hardhat/erc20-token/hardhat.config.ts
@@ -4,16 +4,6 @@ require("dotenv").config();
 module.exports = {
   solidity: "0.7.6",
   networks: {
-    eosevm_testnet: {
-      accounts: [process.env.PK],
-      url: "https://api.testnet.evm.eosnetwork.com",
-      chainId: 15557,
-    },
-    eosevm_mainnet: {
-      accounts: [process.env.PK],
-      url: "https://api.evm.eosnetwork.com",
-      chainId: 17777,
-    },
     sepolia: {
       accounts: [process.env.PK],
       url: "https://rpc.sepolia.org",


### PR DESCRIPTION
Add Arbitrum one (mainnet) and Arbitrum sepolia (testnet) networks on the hardhat config file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Renamed and updated network configurations for better clarity and accuracy:
    - `eosevm_testnet` is now `sepolia`
    - `eosevm_mainnet` is now `arbitrumOne`
    - `sepolia` is now `arbitrumSepolia`
  - Updated URLs and chain IDs for the renamed networks to reflect their new designations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->